### PR TITLE
Use the safe area for last iPhone models

### DIFF
--- a/src/exercise1/start/Alignment/MainPage.xaml
+++ b/src/exercise1/start/Alignment/MainPage.xaml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:Alignment"
+             xmlns:iOsSpecific="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             iOsSpecific:Page.UseSafeArea="true"
              x:Class="Alignment.MainPage">
 
     <StackLayout Padding="0,20,0,0">


### PR DESCRIPTION
The status bar is blocking part of the horizontal  buttons on iPhone 12 for example.
Using the safe area fix this issue.